### PR TITLE
Added SourceArn to GuardDutytoACLInvokePermissions resource to create…

### DIFF
--- a/templates/guarddutytoacl.template
+++ b/templates/guarddutytoacl.template
@@ -201,6 +201,7 @@ Resources:
     Properties:
       FunctionName: !Ref "GuardDutytoACLLambda"
       Action: "lambda:InvokeFunction"
+      SourceArn: !GetAtt GuardDutytoACLEvent.Arn
       Principal: "events.amazonaws.com"
 
   GuardDutytoACLDDBTable:


### PR DESCRIPTION
Lambda was not having any trigger because of missing sourceArn, that was added